### PR TITLE
Updating the stevedore new docs location

### DIFF
--- a/doc/source/persistence.rst
+++ b/doc/source/persistence.rst
@@ -31,7 +31,7 @@ This abstraction serves the following *major* purposes:
   vs. stop.
 * *Something you create...*
 
-.. _stevedore: http://stevedore.readthedocs.org/
+.. _stevedore: http://docs.openstack.org/developer/stevedore/
 
 How it is used
 ==============


### PR DESCRIPTION
As I was reading through the docs, I notice the old link pointing too stevedore is not a valid link. Fixed it by pointing it to the new openstack link.