### PR TITLE
Add ability to use tooz to find and advertise workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Packages
 *.egg
 *.egg-info
+.eggs/
 dist
 build
 eggs

--- a/doc/source/user/workers.rst
+++ b/doc/source/user/workers.rst
@@ -435,4 +435,12 @@ Components
 .. automodule:: taskflow.engines.worker_based.worker
 .. automodule:: taskflow.engines.worker_based.types
 
+Finders and advertisers
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: taskflow.engines.worker_based.types.WorkerFinder
+.. autoclass:: taskflow.engines.worker_based.types.ProxyWorkerFinder
+.. autoclass:: taskflow.engines.worker_based.types.ToozWorkerAdvertiser
+.. autoclass:: taskflow.engines.worker_based.types.ToozWorkerFinder
+
 .. _kombu: http://kombu.readthedocs.org/

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,3 +53,6 @@ stestr>=2.0.0 # Apache-2.0
 
 # For pydot output tests
 pydot>=1.2.4 # MIT License
+
+# For improved/better wbe worker finding
+tooz>=1.19.0 # Apache-2.0

--- a/taskflow/conductors/backends/impl_executor.py
+++ b/taskflow/conductors/backends/impl_executor.py
@@ -288,7 +288,7 @@ class ExecutorConductor(base.Conductor):
                     ensure_fresh = False
                 job_it = itertools.takewhile(
                     self._can_claim_more_jobs,
-                    self._jobboard.iterjobs(ensure_fresh=ensure_fresh))
+                    self._jobboard.iterjobs(only_unclaimed=True, ensure_fresh=ensure_fresh))
                 for job in job_it:
                     self._log.debug("Trying to claim job: %s", job)
                     try:

--- a/taskflow/engines/worker_based/types.py
+++ b/taskflow/engines/worker_based/types.py
@@ -14,34 +14,43 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import abc
+import functools
 import random
 import threading
 
+from futurist import periodics
 from oslo_utils import reflection
 from oslo_utils import timeutils
 import six
+import tooz
+from tooz import coordination
 
+from taskflow.engines.worker_based import dispatcher
 from taskflow.engines.worker_based import protocol as pr
+from taskflow import exceptions as excp
 from taskflow import logging
+from taskflow.types import notifier
 from taskflow.utils import kombu_utils as ku
+from taskflow.utils import misc
+from taskflow.utils import threading_utils as tu
 
 LOG = logging.getLogger(__name__)
 
 
-# TODO(harlowja): this needs to be made better, once
-# https://blueprints.launchpad.net/taskflow/+spec/wbe-worker-info is finally
-# implemented we can go about using that instead.
 class TopicWorker(object):
-    """A (read-only) worker and its relevant information + useful methods."""
+    """A immutable worker and its relevant information + useful methods."""
 
-    _NO_IDENTITY = object()
+    #: Anonymous/no identity string.
+    NO_IDENTITY = object()
 
-    def __init__(self, topic, tasks, identity=_NO_IDENTITY):
-        self.tasks = []
+    def __init__(self, topic, tasks, identity=NO_IDENTITY):
+        extracted_tasks = []
         for task in tasks:
             if not isinstance(task, six.string_types):
                 task = reflection.get_class_name(task)
-            self.tasks.append(task)
+            extracted_tasks.append(task)
+        self.tasks = tuple(extracted_tasks)
         self.topic = topic
         self.identity = identity
         self.last_seen = None
@@ -61,8 +70,8 @@ class TopicWorker(object):
         for task in other.tasks:
             if not self.performs(task):
                 return False
-        # If one of the identity equals _NO_IDENTITY, then allow it to match...
-        if self._NO_IDENTITY in (self.identity, other.identity):
+        # If one of the identity equals NO_IDENTITY, then allow it to match...
+        if self.NO_IDENTITY in (self.identity, other.identity):
             return True
         else:
             return other.identity == self.identity
@@ -72,35 +81,30 @@ class TopicWorker(object):
 
     def __repr__(self):
         r = reflection.get_class_name(self, fully_qualified=False)
-        if self.identity is not self._NO_IDENTITY:
+        if self.identity is not self.NO_IDENTITY:
             r += "(identity=%s, tasks=%s, topic=%s)" % (self.identity,
                                                         self.tasks, self.topic)
         else:
-            r += "(identity=*, tasks=%s, topic=%s)" % (self.tasks, self.topic)
+            r += "(tasks=%s, topic=%s)" % (self.tasks, self.topic)
         return r
 
 
-class ProxyWorkerFinder(object):
-    """Requests and receives responses about workers topic+task details."""
+@six.add_metaclass(abc.ABCMeta)
+class WorkerFinder(object):
+    """Base class for worker finders..."""
 
-    def __init__(self, uuid, proxy, topics,
-                 beat_periodicity=pr.NOTIFY_PERIOD,
-                 worker_expiry=pr.EXPIRES_AFTER):
+    def __init__(self):
         self._cond = threading.Condition()
-        self._proxy = proxy
-        self._topics = topics
-        self._workers = {}
-        self._uuid = uuid
-        self._seen_workers = 0
-        self._messages_processed = 0
-        self._messages_published = 0
-        self._worker_expiry = worker_expiry
-        self._watch = timeutils.StopWatch(duration=beat_periodicity)
+        self.notifier = notifier.Notifier()
 
     @property
-    def total_workers(self):
-        """Number of workers currently known."""
-        return len(self._workers)
+    def messages_processed(self):
+        """How many notify response messages have been processed."""
+        return 0
+
+    @abc.abstractproperty
+    def available_workers(self):
+        """Returns how many workers are known."""
 
     def wait_for_workers(self, workers=1, timeout=None):
         """Waits for geq workers to notify they are ready to do work.
@@ -112,19 +116,19 @@ class ProxyWorkerFinder(object):
         return zero.
         """
         if workers <= 0:
-            raise ValueError("Worker amount must be greater than zero")
-        watch = timeutils.StopWatch(duration=timeout)
-        watch.start()
-        with self._cond:
-            while self.total_workers < workers:
-                if watch.expired():
-                    return max(0, workers - self.total_workers)
-                self._cond.wait(watch.leftover(return_none=True))
-            return 0
+            raise ValueError("Worker amount to wait for"
+                             " must be greater than zero")
+        with timeutils.StopWatch(duration=timeout) as watch:
+            with self._cond:
+                while self.available_workers < workers:
+                    if watch.expired():
+                        return max(0, workers - self.available_workers)
+                    self._cond.wait(watch.leftover(return_none=True))
+                return 0
 
     @staticmethod
     def _match_worker(task, available_workers):
-        """Select a worker (from geq 1 workers) that can best perform the task.
+        """Select a worker (from >= 1 workers) that can best perform the task.
 
         NOTE(harlowja): this method will be activated when there exists
         one one greater than one potential workers that can perform a task,
@@ -137,6 +141,60 @@ class ProxyWorkerFinder(object):
             return available_workers[0]
         else:
             return random.choice(available_workers)
+
+    @abc.abstractmethod
+    def get_worker_for_task(self, task):
+        """Gets a worker that can perform a given task."""
+
+    @staticmethod
+    def clear():
+        """Clears the known workers (subclass and implement as needed)."""
+
+    @staticmethod
+    def start():
+        """Starts the finding process (subclass and implement as needed)."""
+
+    @staticmethod
+    def stop():
+        """Stops the finding process (subclass and implement as needed)."""
+
+
+class ProxyWorkerFinder(WorkerFinder):
+    """Requests and receives responses about workers topic + task details.
+
+    NOTE(harlowja): This is one of the simplest finder implementations that
+    doesn't have external dependencies (outside of what the engine
+    already requires) and is the default for this reason. It though does
+    create periodic 'polling' traffic to workers to 'learn' of the tasks they
+    can perform (and does require pre-existing knowledge of the topics
+    those workers exist at to gather and update this information).
+    """
+
+    # TODO(harlowja): make these settings more configurable...
+
+    #: How often we ask workers of there new/updated capabilities.
+    NOTIFY_PERIOD = 5
+
+    def __init__(self, uuid, proxy, topics,
+                 beat_periodicity=NOTIFY_PERIOD,
+                 worker_expiry=pr.EXPIRES_AFTER):
+        super(ProxyWorkerFinder, self).__init__()
+        self._proxy = proxy
+        self._topics = topics
+        self._workers = {}
+        self._uuid = uuid
+        self._seen_workers = 0
+        self._messages_processed = 0
+        self._messages_published = 0
+        self._worker_expiry = worker_expiry
+        self._watch = timeutils.StopWatch(duration=beat_periodicity)
+        # TODO (jimbobhickville): this needs to be refactored
+        self._proxy.dispatcher.type_handlers.update({
+            pr.NOTIFY: dispatcher.Handler(
+                self.process_response,
+                validator=functools.partial(pr.Notify.validate,
+                                            response=True)),
+        })
 
     @property
     def messages_processed(self):
@@ -151,12 +209,26 @@ class ProxyWorkerFinder(object):
         else:
             return TopicWorker(topic, tasks)
 
-    def maybe_publish(self):
-        """Periodically called to publish notify message to each topic.
+    @classmethod
+    def generate_factory(cls, options):
+        """Returns a function that generates finders using provided options."""
 
-        These messages (especially the responses) are how this find learns
-        about workers and what tasks they can perform (so that we can then
-        match workers to tasks to run).
+        # TODO(harlowja): this should likely be a real entrypoint someday
+        # in the future...
+        topics = list(options.get('topics', []))
+        worker_expiry = options.get('worker_expiry', pr.EXPIRES_AFTER)
+
+        def factory(uuid, proxy):
+            return cls(uuid, proxy, topics[:], worker_expiry=worker_expiry)
+
+        return factory
+
+    def discover(self):
+        """Publish notify message to each topic to discover new workers
+
+        The response expected from workers is then used to find later
+        tasks to fullfill (as the response from a worker contains the
+        tasks they can perform).
         """
         if self._messages_published == 0:
             self._proxy.publish(pr.Notify(),
@@ -169,6 +241,12 @@ class ProxyWorkerFinder(object):
                                     self._topics, reply_to=self._uuid)
                 self._messages_published += 1
                 self._watch.restart()
+
+        self.clean()
+
+    @property
+    def available_workers(self):
+        return len(self._workers)
 
     def _add(self, topic, tasks):
         """Adds/updates a worker for the topic for the given tasks."""
@@ -189,7 +267,11 @@ class ProxyWorkerFinder(object):
         return (worker, True)
 
     def process_response(self, data, message):
-        """Process notify message sent from remote side."""
+        """Process notify message (response) sent from remote side.
+
+        NOTE(harlowja): the message content should already have had
+        basic validation performed on it...
+        """
         LOG.debug("Started processing notify response message '%s'",
                   ku.DelayedPretty(message))
         response = pr.Notify(**data)
@@ -198,8 +280,9 @@ class ProxyWorkerFinder(object):
             worker, new_or_updated = self._add(response.topic,
                                                response.tasks)
             if new_or_updated:
-                LOG.debug("Updated worker '%s' (%s total workers are"
-                          " currently known)", worker, self.total_workers)
+                LOG.debug("Received notification about worker '%s' (%s"
+                          " total workers are currently known)", worker,
+                          self.available_workers)
                 self._cond.notify_all()
             worker.last_seen = timeutils.now()
             self._messages_processed += 1
@@ -227,6 +310,7 @@ class ProxyWorkerFinder(object):
                 self._cond.notify_all()
         if dead_workers and LOG.isEnabledFor(logging.INFO):
             for worker, secs_since_last_seen in six.itervalues(dead_workers):
+                self.notifier.notify(pr.WORKER_LOST, worker.__dict__)
                 LOG.info("Removed worker '%s' as it has not responded to"
                          " notification requests in %0.3f seconds",
                          worker, secs_since_last_seen)
@@ -252,3 +336,434 @@ class ProxyWorkerFinder(object):
             return self._match_worker(task, available_workers)
         else:
             return None
+
+
+class ToozWorkerAdvertiser(object):
+    """Advertiser that advertises worker capabilities via `tooz`_ groups.
+
+    .. note::
+
+        It only *advertises* a single workers capabilities (tasks
+        the worker can perform and the topic the worker responds to on) via
+        tooz groups & membership concepts. It **still** requires using a
+        :py:class:`~taskflow.engines.worker_based.proxy.Proxy` for actually
+        performing (and responding to) task requests.
+
+    .. warning::
+
+        This worker is still considered **experimental** and it needs to
+        be used in conjunction with
+        :py:class:`~taskflow.engines.worker_based.types.ToozWorkerFinder`
+        finder/s to achieve a working architecture.
+
+    .. _tooz: http://docs.openstack.org/developer/tooz/
+    """
+
+    # TODO(harlowja): make these settings more configurable...
+
+    BEAT_PERIOD = 1
+    """
+    This is how often we want to heartbeat into the coordinator
+    backend so that we don't get ejected from any groups we are in
+    or lose our connection to that backend; aka this ensures the backend
+    knows we are still alive/not dead.
+    """
+
+    MEMBER_PREFIX = "a+"
+    """
+    Prefix used along with the workers topic used to form a tooz member
+    id (only used when a member id was not provided via the factory functions
+    options).
+    """
+
+    def __init__(self, coordinator_url, member_id, join_groups,
+                 worker_topic, worker_endpoints):
+        self._coordinator = coordination.get_coordinator(coordinator_url,
+                                                         member_id)
+        self._join_groups = frozenset(join_groups)
+        self._helpers = tu.ThreadBundle()
+        self._member_id = member_id
+        self._capabilities = {
+            'topic': worker_topic,
+            'tasks': [e.name for e in worker_endpoints],
+        }
+        p_worker = periodics.PeriodicWorker.create([self])
+        if p_worker:
+            self._helpers.bind(lambda: tu.daemon_thread(p_worker.start),
+                               before_join=lambda t: p_worker.stop(),
+                               after_join=lambda t: p_worker.reset(),
+                               before_start=lambda t: p_worker.reset())
+        self._activator = misc.Activator([self._coordinator, self._helpers])
+
+    @classmethod
+    def generate_factory(cls, options):
+        """Returns a function that generates finders using provided options."""
+
+        # TODO(harlowja): this should likely be a real entrypoint someday
+        # in the future...
+        options = options['coordinator']
+        url = options['url']
+        groups = list(options.get('groups', []))
+
+        def factory(worker):
+            member_id = options.get('member_id')
+            if not member_id:
+                member_id = "".join([cls.MEMBER_PREFIX, worker.topic])
+            return cls(url, member_id, groups,
+                       worker.topic, worker.endpoints)
+
+        return factory
+
+    @misc.cachedproperty
+    def banner_additions(self):
+        return {
+            'Advertiser details': {
+                'kind': reflection.get_class_name(self),
+                'coordinator': reflection.get_class_name(self._coordinator),
+                'member_id': self._member_id,
+                'groups': sorted(self._join_groups),
+            }
+        }
+
+    def advertise(self):
+        # Always try to ensure that the groups we are supposed to be in exist
+        # and that we are still a member of those groups (in-case we have a
+        # disconnect, we may have been booted out, or those groups may have
+        # gone away...); this logic tries to protect against those
+        # scenarios...
+        caps = self._capabilities
+        raw_caps = pr.Capabilities.dumps(**caps)
+        for group_id in self._join_groups:
+            try:
+                self._coordinator.create_group(group_id).get()
+            except coordination.GroupAlreadyExist:
+                pass
+            try:
+                self._coordinator.join_group(group_id,
+                                             capabilities=raw_caps).get()
+            except coordination.MemberAlreadyExist:
+                pass
+            else:
+                LOG.debug("Joined into group '%s' with capabilities %s",
+                          group_id, caps)
+
+    def retract(self):
+        for group_id in self._join_groups:
+            try:
+                self._coordinator.delete_group(group_id).get()
+            except coordination.GroupAlreadyExist:
+                pass
+
+    @periodics.periodic(BEAT_PERIOD, run_immediately=True)
+    def beat(self):
+        # NOTE(harlowja): if the tooz kazoo driver is used, this is basically
+        # a no-op since that driver maintains its own thread that heartbeats
+        # to zookeeper (other tooz drivers though are not this lucky)...
+        try:
+            self._coordinator.heartbeat()
+        except tooz.NotImplemented:
+            pass
+
+    def start(self):
+        self._activator.start()
+        self.advertise()
+
+    def stop(self):
+        self._activator.stop()
+        self.retract()
+
+
+class ToozWorkerFinder(WorkerFinder):
+    """Learns of workers using scanned and watched `tooz`_ groups.
+
+    .. warning::
+
+        This finder is still considered **experimental** and it needs to
+        be used in conjunction with
+        :py:class:`~taskflow.engines.worker_based.types.ToozWorkerAdvertiser`
+        workers to achieve a working architecture.
+
+    .. _tooz: http://docs.openstack.org/developer/tooz/
+    """
+
+    # TODO(harlowja): make these settings more configurable...
+
+    BEAT_PERIOD = 1
+    """
+    This is how often we want to heartbeat into the coordinator
+    backend so that we don't get ejected from any groups we are in
+    or lose our connection to that backend; aka this ensures the backend
+    knows we are still alive/not dead.
+    """
+
+    MEMBER_PREFIX = "f+"
+    """
+    Prefix used along with the engines topic used to form a tooz member
+    id (only used when a member id was not provided via the factory functions
+    options).
+    """
+
+    NOTICE_PERIOD = 10
+    """
+    This is how often a **partial** membership discovery runs (it will only
+    discover workers that have left/joined previously known groups that
+    the instance has established watches on).
+    """
+
+    def __init__(self, coordination_url, member_id, watch_groups):
+        super(ToozWorkerFinder, self).__init__()
+        self._coordinator = coordination.get_coordinator(coordination_url,
+                                                         member_id)
+        self._watch_groups = watch_groups
+        self._active_groups = {}
+        self._available_workers = 0
+
+        self._helpers = tu.ThreadBundle()
+        p_worker = periodics.PeriodicWorker.create([self])
+        if p_worker:
+            self._helpers.bind(lambda: tu.daemon_thread(p_worker.start),
+                               before_join=lambda t: p_worker.stop(),
+                               after_join=lambda t: p_worker.reset(),
+                               before_start=lambda t: p_worker.reset())
+        self._activator = misc.Activator([self._coordinator, self._helpers])
+
+    @classmethod
+    def generate_factory(cls, options):
+        # TODO(harlowja): this should likely be a real entrypoint someday
+        # in the future...
+        options = options['coordinator']
+        url = options['url']
+        groups = list(options.get('groups', []))
+
+        def factory(topic, proxy):
+            member_id = options.get('member_id')
+            if not member_id:
+                member_id = "".join([cls.MEMBER_PREFIX, topic])
+            return cls(url, member_id, groups)
+
+        return factory
+
+    def clear(self):
+        with self._cond:
+            self._active_groups.clear()
+            self._recalculate_available_workers()
+            self._cond.notify_all()
+
+    def get_worker_for_task(self, task):
+        available_workers = []
+        with self._cond:
+            for workers in six.itervalues(self._active_groups):
+                for worker in workers:
+                    if worker.performs(task):
+                        available_workers.append(worker)
+        if available_workers:
+            return self._match_worker(task, available_workers)
+        else:
+            return None
+
+    def start(self):
+        self.clear()
+        self._activator.start()
+        self.discover()
+
+    def stop(self):
+        self._activator.stop()
+        self.clear()
+
+    @property
+    def available_workers(self):
+        return self._available_workers
+
+    def _recalculate_available_workers(self):
+        # This is *always* called in a locked manner; if it is not then
+        # this will likely fail iteration if some other thread mutates these
+        # groups at the same time this iteration is ongoing...
+        available = 0
+        for workers in six.itervalues(self._active_groups):
+            available += len(workers)
+        self._available_workers = available
+
+    def _on_member(self, group_id, member_id):
+        try:
+            result = self._coordinator.get_member_capabilities(group_id,
+                                                               member_id)
+            raw_capabilities = result.get()
+        except coordination.ToozError:
+            LOG.warn("Failed getting capabilities of '%s' in group '%s'",
+                     member_id, group_id, exc_info=True)
+            return None
+        else:
+            try:
+                topic, tasks = pr.Capabilities.loads(raw_capabilities)
+                worker = TopicWorker(topic, tasks, identity=member_id)
+            except (TypeError, excp.InvalidFormat):
+                LOG.warn("Unable to construct a topic worker using newly"
+                         " discovered member '%s' (of group '%s') with"
+                         " capabilities '%s'", member_id, group_id,
+                         raw_capabilities, exc_info=True)
+                return None
+            else:
+                self.notifier.notify(pr.WORKER_FOUND, worker.__dict__)
+                siblings = self._active_groups[group_id]
+                previous_idx = -1
+                overwrite = True
+                for i, w in enumerate(siblings):
+                    if w.identity == worker.identity:
+                        previous_idx = i
+                        if w == worker:
+                            overwrite = False
+                        else:
+                            overwrite = True
+                        # Avoid further searching...
+                        break
+                new_or_updated = True
+                if previous_idx == -1:
+                    siblings.append(worker)
+                else:
+                    if overwrite:
+                        siblings[previous_idx] = worker
+                    else:
+                        new_or_updated = False
+                if new_or_updated:
+                    return worker
+                else:
+                    return None
+
+    def _on_group_deleted(self, group_id):
+        try:
+            self._active_groups.pop(group_id)
+        except KeyError:
+            return 0
+        else:
+            LOG.debug("Got notified that group '%s' was deleted", group_id)
+            self._purge_watch_group(group_id)
+            return 1
+
+    def _purge_watch_group(self, group_id):
+        try:
+            self._coordinator.unwatch_join_group(group_id,
+                                                 self._on_join_member_event)
+        except (KeyError, ValueError):
+            pass
+        try:
+            self._coordinator.unwatch_leave_group(group_id,
+                                                  self._on_leave_member_event)
+        except (KeyError, ValueError):
+            pass
+
+    def _on_join_member_event(self, event):
+        with self._cond:
+            worker = self._on_member(event.group_id, event.member_id)
+            if worker is not None:
+                LOG.debug("Got notified that '%s' now exists (or was"
+                          " updated) in group '%s'", worker, event.group_id)
+                self._recalculate_available_workers()
+                self._cond.notify_all()
+
+    def _on_leave_member(self, group_id, member_id):
+        siblings = self._active_groups.get(group_id, [])
+        previous_idx = -1
+        for i, worker in enumerate(siblings):
+            if member_id == worker.identity:
+                previous_idx = i
+                break
+        if previous_idx != -1:
+            worker = siblings.pop(previous_idx)
+            self.notifier.notify(pr.WORKER_LOST, worker.__dict__)
+            LOG.debug("Got notified that '%s' no longer exists"
+                      " in group '%s'", worker, group_id)
+            return worker
+        return None
+
+    def _on_leave_member_event(self, event):
+        with self._cond:
+            worker = self._on_leave_member(event.group_id, event.member_id)
+            if worker is not None:
+                self._recalculate_available_workers()
+                self._cond.notify_all()
+
+    def _establish_watch_group(self, group_id):
+        expunge = False
+        try:
+            self._coordinator.watch_join_group(group_id,
+                                               self._on_join_member_event)
+            self._coordinator.watch_leave_group(group_id,
+                                                self._on_leave_member_event)
+        except coordination.GroupNotCreated:
+            expunge = True
+        except coordination.ToozError:
+            expunge = True
+            LOG.warn("Unexpected failure binding watchers to join/leaves"
+                     " of group '%s'", group_id, exc_info=True)
+        if expunge:
+            self._purge_watch_group(group_id)
+
+    def _on_group_exists(self, group_id):
+        if group_id not in self._active_groups:
+            LOG.debug("Got notified that group '%s' was created", group_id)
+            self._active_groups[group_id] = []
+            self._establish_watch_group(group_id)
+        new_updated_workers = []
+        workers_deleted = 0
+        try:
+            group_members = self._coordinator.get_members(group_id).get()
+            gone_members = set()
+            for worker in self._active_groups[group_id]:
+                if worker.identity not in group_members:
+                    gone_members.add(worker.identity)
+            while gone_members:
+                worker = self._on_leave_member(group_id, gone_members.pop())
+                if worker is not None:
+                    workers_deleted += 1
+            for member_id in group_members:
+                worker = self._on_member(group_id, member_id)
+                if worker is not None:
+                    new_updated_workers.append(worker)
+                    LOG.debug("Got notified that '%s' now exists (or was"
+                              " updated) in group '%s'", worker, group_id)
+        except coordination.GroupNotCreated:
+            pass
+        except coordination.ToozError:
+            LOG.warn("Unexpected failure getting members of group '%s'"
+                     " from coordinator", group_id, exc_info=True)
+        return (new_updated_workers, workers_deleted)
+
+    @periodics.periodic(NOTICE_PERIOD, run_immediately=False)
+    def notice(self):
+        try:
+            self._coordinator.run_watchers()
+        except tooz.NotImplemented:
+            pass
+        except coordination.ToozError:
+            LOG.warn("Unexpected failure running coordinator watchers",
+                     exc_info=True)
+
+    def discover(self):
+        try:
+            potential_groups = set(self._coordinator.get_groups().get())
+        except coordination.ToozError:
+            LOG.warn("Unexpected failure getting all groups from"
+                     " coordinator", exc_info=True)
+        else:
+            with self._cond:
+                deletes = 0
+                for group_id in set(six.iterkeys(self._active_groups)):
+                    if group_id not in potential_groups:
+                        deletes += self._on_group_deleted(group_id)
+                workers = []
+                for group_id in potential_groups:
+                    if group_id not in self._watch_groups:
+                        continue
+                    tmp_workers, tmp_deleted = self._on_group_exists(group_id)
+                    workers.extend(tmp_workers)
+                    deletes += tmp_deleted
+                if deletes or workers:
+                    self._recalculate_available_workers()
+                    self._cond.notify_all()
+
+    @periodics.periodic(BEAT_PERIOD, run_immediately=True)
+    def beat(self):
+        try:
+            self._coordinator.heartbeat()
+        except tooz.NotImplemented:
+            pass

--- a/taskflow/engines/worker_based/worker.py
+++ b/taskflow/engines/worker_based/worker.py
@@ -18,9 +18,11 @@ import os
 import platform
 import socket
 import sys
+import threading
 
 import futurist
 from oslo_utils import reflection
+import six
 
 from taskflow.engines.worker_based import endpoint
 from taskflow.engines.worker_based import server
@@ -55,12 +57,19 @@ class Worker(object):
                               options imply and are expected to be)
     :param retry_options: retry specific options
                           (see: :py:attr:`~.proxy.Proxy.DEFAULT_RETRY_OPTIONS`)
+    :param advertiser_factory: factory function that will generate a advertiser
+                               that can be used with this worker to advertise
+                               its capabilities via some mechanism (the
+                               default will use the built-in *passive*
+                               mechanism that responds to requests
+                               for a workers capabilities with that workers
+                               capabilities).
     """
 
     def __init__(self, exchange, topic, tasks,
                  executor=None, threads_count=None, url=None,
                  transport=None, transport_options=None,
-                 retry_options=None):
+                 retry_options=None, advertiser_factory=None):
         self._topic = topic
         self._executor = executor
         self._owns_executor = False
@@ -68,13 +77,43 @@ class Worker(object):
             self._executor = futurist.ThreadPoolExecutor(
                 max_workers=threads_count)
             self._owns_executor = True
-        self._endpoints = self._derive_endpoints(tasks)
+        self._endpoints = tuple(self._derive_endpoints(tasks))
         self._exchange = exchange
         self._server = server.Server(topic, exchange, self._executor,
                                      self._endpoints, url=url,
                                      transport=transport,
                                      transport_options=transport_options,
                                      retry_options=retry_options)
+        self._advertiser = None
+        self._advertiser_lock = threading.Lock()
+        if advertiser_factory is not None:
+            if not six.callable(advertiser_factory):
+                raise ValueError("Provided factory used to build worker"
+                                 " advertisers must be callable")
+            self._advertiser_factory = advertiser_factory
+        else:
+            self._advertiser_factory = None
+
+    @property
+    def topic(self):
+        """Topic this worker responds to on (similar to a phone number)."""
+        return self._topic
+
+    @property
+    def endpoints(self):
+        """Read-only list of endpoints/tasks this worker can perform."""
+        return self._endpoints
+
+    def _fetch_advertiser(self):
+        # Lazily populate the advertiser attribute/instance so that subclasses
+        # of workers function correctly (and so that the factory gets a
+        # instance that has been constructed fully, instead of one that is
+        # partially created/under construction...).
+        with self._advertiser_lock:
+            if self._advertiser is None:
+                if self._advertiser_factory is not None:
+                    self._advertiser = self._advertiser_factory(self)
+            return self._advertiser
 
     @staticmethod
     def _derive_endpoints(tasks):
@@ -101,6 +140,9 @@ class Worker(object):
         except OSError:
             pid = "???"
         chapters = {
+            'Worker details': {
+                'Kind': reflection.get_class_name(self),
+            },
             'Connection details': {
                 'Driver': transport_driver,
                 'Exchange': self._exchange,
@@ -121,16 +163,27 @@ class Worker(object):
                 'Thread id': tu.get_ident(),
             },
         }
+        advertiser = self._fetch_advertiser()
+        if advertiser is not None:
+            banner_additions = getattr(advertiser, 'banner_additions', {})
+            if banner_additions:
+                chapters.update(banner_additions)
+
         return banner.make_banner('WBE worker', chapters)
 
     def run(self, display_banner=True, banner_writer=None):
-        """Runs the worker."""
+        """Runs the worker component(s)."""
         if display_banner:
             if banner_writer is None:
                 for line in self.banner.splitlines():
                     LOG.info(line)
             else:
                 banner_writer(self.banner)
+
+        advertiser = self._fetch_advertiser()
+        if advertiser is not None:
+            advertiser.start()
+
         self._server.start()
 
     def wait(self):
@@ -138,10 +191,14 @@ class Worker(object):
         self._server.wait()
 
     def stop(self):
-        """Stop worker."""
+        """Stop the worker component(s)."""
         self._server.stop()
         if self._owns_executor:
             self._executor.shutdown()
+
+        advertiser = self._fetch_advertiser()
+        if advertiser is not None:
+            advertiser.stop()
 
 
 if __name__ == '__main__':

--- a/taskflow/examples/tooz_wbe_example.py
+++ b/taskflow/examples/tooz_wbe_example.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+
+#    Copyright (C) 2015 Yahoo! Inc. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from __future__ import print_function
+
+import logging
+import os
+import sys
+
+self_dir = os.path.abspath(os.path.dirname(__file__))
+top_dir = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                       os.pardir,
+                                       os.pardir))
+sys.path.insert(0, top_dir)
+sys.path.insert(0, self_dir)
+
+logging.basicConfig(level=logging.ERROR)
+
+from oslo_utils import uuidutils
+
+from taskflow import engines
+from taskflow.engines.worker_based import executor
+from taskflow.engines.worker_based import types as wt
+from taskflow.engines.worker_based import worker
+from taskflow.patterns import linear_flow as lf
+from taskflow import task
+from taskflow.utils import persistence_utils as pu
+from taskflow.utils import threading_utils as tu
+
+
+# Some simple utility functions.
+
+def banner_writer(banner):
+    for line in banner.splitlines():
+        print(" %s" % line)
+
+
+# Some dummy tasks that would typically do something more complex...
+
+class TwoTask(task.Task):
+    default_provides = 'two'
+
+    def execute(self):
+        return 2
+
+
+class OneTask(task.Task):
+    default_provides = 'one'
+
+    def execute(self):
+        return 1
+
+
+# Settings that the tooz worker + finder need to learn of each other...
+#
+# See: http://docs.openstack.org/developer/tooz/
+coordinator_groups = ['x', 'y', 'z']
+coordinator_groups = frozenset(x.encode('ascii') for x in coordinator_groups)
+coordinator_url = "zake://localhost"
+
+# Settings used when interacting with kombu...
+#
+# See: http://kombu.readthedocs.org/
+exchange = 'default'
+transport = 'memory'
+
+# Create & start our worker that will actually run tasks..
+#
+# It will join 'coordinator_groups' groups and advertise its capabilities in
+# those groups (so that engines may find it).
+worker_id = uuidutils.generate_uuid()
+advertiser_factory = wt.ToozWorkerAdvertiser.generate_factory({
+    'coordinator': {
+        'url': coordinator_url,
+        'groups': coordinator_groups,
+    },
+})
+w = worker.Worker(exchange, uuidutils.generate_uuid(), [OneTask, TwoTask],
+                  transport=transport, advertiser_factory=advertiser_factory)
+w_runner = tu.daemon_thread(target=w.run, banner_writer=banner_writer)
+
+print("Booting up the worker...")
+w_runner.start()
+w.wait()
+
+# Now make the engine that will use the previous workers to do some work...
+finder_factory = wt.ToozWorkerFinder.generate_factory({
+    'coordinator': {
+        'url': coordinator_url,
+        'groups': coordinator_groups,
+    },
+})
+
+# Create a custom executor for the engine to use.
+#
+# TODO(harlowja): this will be fixed in a future version (so that instead
+# of doing this an entrypoint can be requested instead).
+executor_id = uuidutils.generate_uuid()
+ex = executor.WorkerTaskExecutor(executor_id, exchange, finder_factory,
+                                 transport=transport,
+                                 # How long (in seconds) we will wait to find
+                                 # a worker before timing out the request(s).
+                                 transition_timeout=60)
+
+# Now create some work and run it in a worker engine!
+f = lf.Flow('dummy')
+f.add(OneTask('1'), TwoTask('2'))
+
+print("Running...")
+eng = engines.load(f, pu.create_flow_detail(f), executor=ex, engine='workers')
+for st in eng.run_iter():
+    print(" -> %s" % st)
+print('Done!!')
+print("Results: %s" % eng.storage.fetch_all())
+print("Shutting down the worker...")
+w.stop()
+w_runner.join()
+
+print('Goodbye!!')

--- a/taskflow/tests/unit/test_utils_iter_utils.py
+++ b/taskflow/tests/unit/test_utils_iter_utils.py
@@ -18,6 +18,7 @@ import string
 
 import six
 from six.moves import range as compat_range
+import testscenarios
 
 from taskflow import test
 from taskflow.utils import iter_utils
@@ -154,3 +155,53 @@ class IterUtilsTest(test.TestCase):
         it = iter(string.ascii_lowercase)
         self.assertEqual(list(string.ascii_lowercase),
                          list(iter_utils.while_is_not(it, '')))
+
+
+class TestReversedEnumerate(testscenarios.TestWithScenarios, test.TestCase):
+    scenarios = [
+        ('ten', {'sample': [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]}),
+        ('empty', {'sample': []}),
+        ('negative', {'sample': [-1, -2, -3]}),
+        ('one', {'sample': [1]}),
+        ('abc', {'sample': ['a', 'b', 'c']}),
+        ('ascii_letters', {'sample': list(string.ascii_letters)}),
+    ]
+
+    def test_sample_equivalence(self):
+        expected = list(reversed(list(enumerate(self.sample))))
+        actual = list(iter_utils.reverse_enumerate(self.sample))
+        self.assertEqual(expected, actual)
+
+
+class TestCountdownIter(test.TestCase):
+    def test_expected_count(self):
+        upper = 100
+        it = iter_utils.countdown_iter(upper)
+        items = []
+        for i in it:
+            self.assertEqual(upper, i)
+            upper -= 1
+            items.append(i)
+        self.assertEqual(0, upper)
+        self.assertEqual(100, len(items))
+
+    def test_no_count(self):
+        it = iter_utils.countdown_iter(0)
+        self.assertEqual(0, len(list(it)))
+        it = iter_utils.countdown_iter(-1)
+        self.assertEqual(0, len(list(it)))
+
+    def test_expected_count_custom_decr(self):
+        upper = 100
+        it = iter_utils.countdown_iter(upper, decr=2)
+        items = []
+        for i in it:
+            self.assertEqual(upper, i)
+            upper -= 2
+            items.append(i)
+        self.assertEqual(0, upper)
+        self.assertEqual(50, len(items))
+
+    def test_invalid_decr(self):
+        it = iter_utils.countdown_iter(10, -1)
+        self.assertRaises(ValueError, six.next, it)

--- a/taskflow/tests/unit/worker_based/test_pipeline.py
+++ b/taskflow/tests/unit/worker_based/test_pipeline.py
@@ -22,6 +22,7 @@ from taskflow.engines.action_engine import executor as base_executor
 from taskflow.engines.worker_based import endpoint
 from taskflow.engines.worker_based import executor as worker_executor
 from taskflow.engines.worker_based import server as worker_server
+from taskflow.engines.worker_based import types as wt
 from taskflow import test
 from taskflow.tests import utils as test_utils
 from taskflow.types import failure
@@ -49,10 +50,13 @@ class TestPipeline(test.TestCase):
         return (server, server_thread)
 
     def _fetch_executor(self):
+        finder_factory = wt.ProxyWorkerFinder.generate_factory({
+            'topics': [TEST_TOPIC],
+        })
         executor = worker_executor.WorkerTaskExecutor(
             uuidutils.generate_uuid(),
             TEST_EXCHANGE,
-            [TEST_TOPIC],
+            finder_factory,
             transport='memory',
             transport_options={
                 'polling_interval': POLLING_INTERVAL,

--- a/taskflow/tests/unit/worker_based/test_types.py
+++ b/taskflow/tests/unit/worker_based/test_types.py
@@ -14,7 +14,11 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import functools
+
+from oslo_serialization import jsonutils
 from oslo_utils import reflection
+from tooz import coordination
 
 from taskflow.engines.worker_based import types as worker_types
 from taskflow import test
@@ -42,7 +46,7 @@ class TestProxyFinder(test.TestCase):
         w.last_seen = 0
         mock_now.side_effect = [120]
         gone = finder.clean()
-        self.assertEqual(0, finder.total_workers)
+        self.assertEqual(0, finder.available_workers)
         self.assertEqual(1, gone)
 
     def test_single_topic_worker(self):
@@ -50,7 +54,7 @@ class TestProxyFinder(test.TestCase):
         w, emit = finder._add('dummy-topic', [utils.DummyTask])
         self.assertIsNotNone(w)
         self.assertTrue(emit)
-        self.assertEqual(1, finder.total_workers)
+        self.assertEqual(1, finder.available_workers)
         w2 = finder.get_worker_for_task(utils.DummyTask)
         self.assertEqual(w.identity, w2.identity)
 
@@ -72,8 +76,174 @@ class TestProxyFinder(test.TestCase):
         added.append(finder._add('dummy-topic', [utils.DummyTask]))
         added.append(finder._add('dummy-topic-2', [utils.DummyTask]))
         added.append(finder._add('dummy-topic-3', [utils.NastyTask]))
-        self.assertEqual(3, finder.total_workers)
+        self.assertEqual(3, finder.available_workers)
         w = finder.get_worker_for_task(utils.NastyTask)
         self.assertEqual(added[-1][0].identity, w.identity)
         w = finder.get_worker_for_task(utils.DummyTask)
         self.assertIn(w.identity, [w_a[0].identity for w_a in added[0:2]])
+
+
+class ToozFakeResult(object):
+    def __init__(self, result):
+        self.result = result
+
+    def get(self, timeout=None):
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+class TestToozFinder(test.TestCase):
+    def setUp(self):
+        super(TestToozFinder, self).setUp()
+        self.coordinator = mock.create_autospec(
+            coordination.CoordinationDriver, instance=True)
+
+    @mock.patch('tooz.coordination.get_coordinator')
+    def test_empty_groups(self, get_coordinator_mock):
+        get_coordinator_mock.return_value = self.coordinator
+        finder = worker_types.ToozWorkerFinder("blah://", 'me', ['a', 'b'])
+        self.coordinator.get_groups.return_value = ToozFakeResult(['a', 'b'])
+        finder.start()
+        finder.discover()
+        self.assertTrue(self.coordinator.start.called)
+        self.assertTrue(self.coordinator.get_groups.called)
+        self.assertTrue(self.coordinator.get_members.called)
+        self.assertTrue(self.coordinator.watch_join_group.called)
+        self.assertTrue(self.coordinator.watch_leave_group.called)
+        self.coordinator.get_members.return_value = ToozFakeResult([])
+        self.coordinator.get_members.assert_any_call('a')
+        self.coordinator.get_members.assert_any_call('b')
+        self.assertEqual(0, finder.available_workers)
+
+    @mock.patch('tooz.coordination.get_coordinator')
+    def test_non_empty_group_single_worker(self, get_coordinator_mock):
+        get_coordinator_mock.return_value = self.coordinator
+        finder = worker_types.ToozWorkerFinder("blah://", 'me', ['a'])
+        self.coordinator.get_groups.return_value = ToozFakeResult(['a'])
+        self.coordinator.get_members.return_value = ToozFakeResult(['e'])
+        worker_capabilities = {
+            'topic': '1-202-555-0198',
+            'tasks': ['y', 'z'],
+        }
+        worker_result = ToozFakeResult(jsonutils.dumps(worker_capabilities))
+        self.coordinator.get_member_capabilities.return_value = worker_result
+        finder.start()
+        self.assertEqual(1, finder.available_workers)
+        w = finder.get_worker_for_task('y')
+        self.assertIsNotNone(w)
+        self.assertEqual(w.identity, 'e')
+        self.assertTrue(w.performs('z'))
+        self.coordinator.get_members.assert_any_call('a')
+        finder.clear()
+        self.assertEqual(0, finder.available_workers)
+
+    @mock.patch('tooz.coordination.get_coordinator')
+    def test_empty_group_watch_join_triggered(self, get_coordinator_mock):
+        join_watchers = []
+        leave_watchers = []
+        capture_join_watchers = lambda g, cb: join_watchers.append((g, cb))
+        capture_leave_watchers = lambda g, cb: leave_watchers.append((g, cb))
+
+        def run_watchers(watchers, event):
+            for g, cb in watchers:
+                cb(event)
+
+        get_coordinator_mock.return_value = self.coordinator
+        finder = worker_types.ToozWorkerFinder("blah://", 'me', ['a'])
+        self.coordinator.get_groups.return_value = ToozFakeResult(['a'])
+        self.coordinator.get_members.return_value = ToozFakeResult([])
+        self.coordinator.watch_join_group.side_effect = capture_join_watchers
+        self.coordinator.watch_leave_group.side_effect = capture_leave_watchers
+        finder.start()
+        self.assertEqual(0, finder.available_workers)
+        self.assertEqual(1, len(join_watchers))
+        self.assertEqual(1, len(leave_watchers))
+
+        event = coordination.MemberJoinedGroup('a', 'y')
+        run_join_watchers = functools.partial(run_watchers, join_watchers,
+                                              event)
+        self.coordinator.run_watchers.side_effect = run_join_watchers
+        worker_capabilities = {
+            'topic': '1-202-555-0133',
+            'tasks': ['y', 'z'],
+        }
+        worker_result = ToozFakeResult(jsonutils.dumps(worker_capabilities))
+        self.coordinator.get_member_capabilities.return_value = worker_result
+        finder.notice()
+        self.assertTrue(self.coordinator.get_member_capabilities.called)
+        self.coordinator.get_member_capabilities.assert_any_call('a', 'y')
+
+        self.assertEqual(1, finder.available_workers)
+        w = finder.get_worker_for_task('y')
+        self.assertIsNotNone(w)
+
+    @mock.patch('tooz.coordination.get_coordinator')
+    def test_group_appear_disappear(self, get_coordinator_mock):
+        get_coordinator_mock.return_value = self.coordinator
+        finder = worker_types.ToozWorkerFinder("blah://", 'me', ['a'])
+        self.coordinator.get_groups.return_value = ToozFakeResult(['a'])
+        self.coordinator.get_members.return_value = ToozFakeResult(['x', 'y'])
+        workers = {
+            'x': {
+                'topic': '1-202-555-0122',
+                'tasks': [],
+            },
+            'y': {
+                'topic': '1-202-555-0165',
+                'tasks': [],
+            },
+        }
+
+        def get_worker_capabilities(group_id, member_id):
+            return ToozFakeResult(jsonutils.dumps(workers[member_id]))
+
+        get_member_capabilities = self.coordinator.get_member_capabilities
+        get_member_capabilities.side_effect = get_worker_capabilities
+
+        finder.start()
+        self.assertEqual(2, finder.available_workers)
+
+        self.coordinator.get_groups.return_value = ToozFakeResult([])
+        finder.discover()
+        self.assertEqual(0, finder.available_workers)
+
+        self.assertEqual(2, self.coordinator.get_groups.call_count)
+
+    @mock.patch('tooz.coordination.get_coordinator')
+    def test_member_appear_disappear(self, get_coordinator_mock):
+        get_coordinator_mock.return_value = self.coordinator
+        workers = {
+            'x': {
+                'topic': '1-202-555-0122',
+                'tasks': [],
+            },
+            'y': {
+                'topic': '1-202-555-0165',
+                'tasks': [],
+            },
+        }
+
+        def get_worker_capabilities(group_id, member_id):
+            return ToozFakeResult(jsonutils.dumps(workers[member_id]))
+
+        finder = worker_types.ToozWorkerFinder("blah://", 'me', ['a'])
+        self.coordinator.get_groups.return_value = ToozFakeResult(['a'])
+        self.coordinator.get_members.return_value = ToozFakeResult(['x', 'y'])
+        get_member_capabilities = self.coordinator.get_member_capabilities
+        get_member_capabilities.side_effect = get_worker_capabilities
+
+        finder.start()
+        self.assertEqual(2, finder.available_workers)
+
+        self.coordinator.get_groups.return_value = ToozFakeResult(['a'])
+        self.coordinator.get_members.return_value = ToozFakeResult(['y'])
+        finder.discover()
+        self.assertEqual(1, finder.available_workers)
+
+    @mock.patch('tooz.coordination.get_coordinator')
+    def test_beat(self, get_coordinator_mock):
+        get_coordinator_mock.return_value = self.coordinator
+        finder = worker_types.ToozWorkerFinder("blah://", 'me', ['a'])
+        finder.beat()
+        self.assertEqual(1, self.coordinator.heartbeat.call_count)

--- a/taskflow/tests/unit/worker_based/test_worker.py
+++ b/taskflow/tests/unit/worker_based/test_worker.py
@@ -57,11 +57,11 @@ class TestWorker(test.MockTestCase):
         master_mock_calls = [
             mock.call.executor_class(max_workers=None),
             mock.call.Server(self.topic, self.exchange,
-                             self.executor_inst_mock, [],
+                             self.executor_inst_mock, (),
                              url=self.broker_url,
                              transport_options=mock.ANY,
                              transport=mock.ANY,
-                             retry_options=mock.ANY)
+                             retry_options=mock.ANY,)
         ]
         self.assertEqual(master_mock_calls, self.master_mock.mock_calls)
 
@@ -79,7 +79,7 @@ class TestWorker(test.MockTestCase):
         master_mock_calls = [
             mock.call.executor_class(max_workers=10),
             mock.call.Server(self.topic, self.exchange,
-                             self.executor_inst_mock, [],
+                             self.executor_inst_mock, (),
                              url=self.broker_url,
                              transport_options=mock.ANY,
                              transport=mock.ANY,
@@ -92,7 +92,7 @@ class TestWorker(test.MockTestCase):
         self.worker(executor=executor_mock)
 
         master_mock_calls = [
-            mock.call.Server(self.topic, self.exchange, executor_mock, [],
+            mock.call.Server(self.topic, self.exchange, executor_mock, (),
                              url=self.broker_url,
                              transport_options=mock.ANY,
                              transport=mock.ANY,

--- a/taskflow/utils/iter_utils.py
+++ b/taskflow/utils/iter_utils.py
@@ -124,6 +124,27 @@ def find_first_match(it, matcher, not_found_value=None):
     return not_found_value
 
 
+def countdown_iter(start_at, decr=1):
+    """Generator that decrements after each generation until <= zero.
+
+    NOTE(harlowja): we can likely remove this when we can use an
+    ``itertools.count`` that takes a step (on py2.6 which we still support
+    that step parameter does **not** exist and therefore can't be used).
+    """
+    if decr <= 0:
+        raise ValueError("Decrement value must be greater"
+                         " than zero and not %s" % decr)
+    while start_at > 0:
+        yield start_at
+        start_at -= decr
+
+
+def reverse_enumerate(items):
+    """Like reversed(enumerate(items)) but with less copying/cloning..."""
+    for i in countdown_iter(len(items)):
+        yield i - 1, items[i - 1]
+
+
 @_ensure_iterable
 def while_is_not(it, stop_value):
     """Yields given values from iterator until stop value is passed.

--- a/taskflow/utils/threading_utils.py
+++ b/taskflow/utils/threading_utils.py
@@ -21,7 +21,7 @@ import threading
 import six
 from six.moves import _thread
 
-from taskflow.utils import misc
+from taskflow.utils import iter_utils
 
 
 def is_alive(thread):
@@ -144,7 +144,7 @@ class ThreadBundle(object):
         """Stops & joins all associated threads (that have been started)."""
         count = 0
         with self._lock:
-            it = misc.reverse_enumerate(self._threads)
+            it = iter_utils.reverse_enumerate(self._threads)
             for i, (builder, thread, started) in it:
                 if not thread or not started:
                     continue


### PR DESCRIPTION
Instead of having a not very optimal (but good for a default) worker
capability discovery process that involves periodic message queue
pings/pongs we can use the ability of the tooz library to maintain groups
and information about members that are in each group to expose (and find)
that same information in a more decoupled manner.

Part of blueprint wbe-worker-info

Part of blueprint use-tooz-for-membership

Change-Id: Icb43c345024ebd7845b8b02a9e0aeb3255bf2f1f